### PR TITLE
UAF-2643 - Adding command to delete any existing .runnable files

### DIFF
--- a/bin/tomcat-ctl
+++ b/bin/tomcat-ctl
@@ -172,6 +172,7 @@ tomcat_start () {
         cd /git-clones/katt-kfs-rhubarb/ && bundle install
         cd /git-clones/katt-kfs-rhubarb/ && cap local deploy
         cd $startdir
+        rm /transactional/work/control/*.runnable
         touch /transactional/work/control/$HOSTNAME.runnable
         rm -R /git-clones
         service ssh stop


### PR DESCRIPTION
UAF-2643 - Adding command to delete any existing .runnable files in the /transactional/work/control directory in order to ensure the one that is created at Rhubarb deployment is the only .runnable in the directory.
